### PR TITLE
Added additional symbol info values and dyn-symbols

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -23,10 +23,10 @@
    :bytes-to-int :int-to-bytes
    :bits-to-int  :int-to-bits
    :named-section :elf-p :elf-header
-   :get-endianness
    :read-elf :write-elf
    :show-dynamic :show-symbols :show-file-layout :show-memory-layout
-   :mapslots :generic-copy :copy-elf :named-symbol :symbols
+   :mapslots :generic-copy :copy-elf :named-symbol :symbols :dyn-symbols
+   :all-symbols
    :file-offset-of-ea
    ;; Modification functions
    :index-of-ea
@@ -44,7 +44,7 @@
    ;; disassembly functionality
    :disassemblable :objdump :csurf :sw-project :disassemble-section
    :elf-const :objdump-const
-   :objdump-cmd :objdump :parse-objdump-line :objdump-parse
+   :objdump-cmd :objdump :parse-addresses :objdump-parse
    :*single-value-objdump-hack*
    :csurf-cmd
    :csurf-script


### PR DESCRIPTION
Added additional symbol info values, dyn-symbols, and all-symbols methods.

This allows symbol types like "GNU Unique Object", "Common Objects", and other "reserved" values to be parsed.
Similarly "reserved" bind types were added.

ELF methods `dyn-symbols` and `all-symbols` were added to read `.dynsym` data.
These new methods and the existing `symbols` method now return `NIL` if their respective section is not present. This is important because currently invoking `(symbols (read-elf "/usr/lib64/libstdc++.so.6"))` for example will crash attempting to invoke `(data NIL)` - this is because many shared libraries carry only a `.dynsym` section.