### PR TITLE
Fullinfo and dynsym

### DIFF
--- a/elf.lisp
+++ b/elf.lisp
@@ -1303,15 +1303,6 @@ section (in the file)."
     (car (member (coerce (read-value 'string in :length 4) 'list)
                  elf-magic-numbers :test #'equalp))))
 
-(defun elf-header-endianness-warn (header)
-  "Raise a warning if HEADER was read using the wrong endianness."
-  (when (if (eq *endian* :little)
-            (= (data-encoding header) 2)
-            (= (data-encoding header) 1))
-    (warn "Header read with wrong encoding ~S while data-encoding ~S."
-          *endian* (data-encoding header)))
-  header)
-
 (defgeneric get-endianness (in)
   (:documentation "Read the endianness byte of a file and set *ENDIAN* appropriately.
 On an existing file stream this does not change the file-position of the stream.")
@@ -1337,6 +1328,15 @@ On an existing file stream this does not change the file-position of the stream.
                            in b)))))
         (file-position in initial-pos))
       *endian*)))
+
+(defun elf-header-endianness-warn (header)
+  "Raise a warning if HEADER was read using the wrong endianness."
+  (when (if (eq *endian* :little)
+            (= (data-encoding header) 2)
+            (= (data-encoding header) 1))
+    (warn "Header read with wrong encoding ~S while data-encoding ~S."
+          *endian* (data-encoding header)))
+  header)
 
 (defun elf-header (file)
   (with-open-file (in file :element-type '(unsigned-byte 8))
@@ -1476,7 +1476,8 @@ Each element of the resulting list is a triplet of (offset size header)."
   (format t "-------------------------------------~%")
   (mapc (lambda-bind ((addr contents end))
                      (format t "~&0x~6,'0x ~18a 0x~6,'0x~%" addr contents end))
-        (list-memory-layout elf)))
+        (list-memory-layout elf))
+  nil)
 
 
 (defgeneric file-offset-of-ea (elf ea)

--- a/elf.lisp
+++ b/elf.lisp
@@ -1479,7 +1479,6 @@ Each element of the resulting list is a triplet of (offset size header)."
         (list-memory-layout elf))
   nil)
 
-
 (defgeneric file-offset-of-ea (elf ea)
   (:documentation "Return the file offset in ELF of EA."))
 

--- a/package.lisp
+++ b/package.lisp
@@ -23,6 +23,7 @@
    :bytes-to-int :int-to-bytes
    :bits-to-int  :int-to-bits
    :named-section :elf-p :elf-header
+   :get-endianness
    :read-elf :write-elf
    :show-dynamic :show-symbols :show-file-layout :show-memory-layout
    :mapslots :generic-copy :copy-elf :named-symbol :symbols :dyn-symbols
@@ -44,7 +45,7 @@
    ;; disassembly functionality
    :disassemblable :objdump :csurf :sw-project :disassemble-section
    :elf-const :objdump-const
-   :objdump-cmd :objdump :parse-addresses :objdump-parse
+   :objdump-cmd :objdump :parse-objdump-line :objdump-parse
    :*single-value-objdump-hack*
    :csurf-cmd
    :csurf-script

--- a/package.lisp
+++ b/package.lisp
@@ -23,10 +23,10 @@
    :bytes-to-int :int-to-bytes
    :bits-to-int  :int-to-bits
    :named-section :elf-p :elf-header
-   :get-endianness
    :read-elf :write-elf
    :show-dynamic :show-symbols :show-file-layout :show-memory-layout
-   :mapslots :generic-copy :copy-elf :named-symbol :symbols
+   :mapslots :generic-copy :copy-elf :named-symbol :symbols :dyn-symbols
+   :all-symbols
    :file-offset-of-ea
    ;; Modification functions
    :index-of-ea
@@ -44,7 +44,7 @@
    ;; disassembly functionality
    :disassemblable :objdump :csurf :sw-project :disassemble-section
    :elf-const :objdump-const
-   :objdump-cmd :objdump :parse-objdump-line :objdump-parse
+   :objdump-cmd :objdump :parse-addresses :objdump-parse
    :*single-value-objdump-hack*
    :csurf-cmd
    :csurf-script


### PR DESCRIPTION
Added additional symbol info values, dyn-symbols, and all-symbols methods.

This allows symbol types like "GNU Unique Object", "Common Objects", and other "reserved" values to be parsed.
Similarly "reserved" bind types were added.

ELF methods dyn-symbols and all-symbols were added to read .dynsym data.
These new methods and the existing symbols method now return NIL if their respective section is not present. This is important because currently invoking (symbols (read-elf "/usr/lib64/libstdc++.so.6")) for example will crash attempting to invoke (data NIL) - this is because many shared libraries carry only a .dynsym section.

Note : Resubmitting this PR after merging latest changes from `master`.